### PR TITLE
feat: allow read() with tuple_key=None for store-wide tuple enumeration

### DIFF
--- a/src/client_ext.rs
+++ b/src/client_ext.rs
@@ -177,6 +177,19 @@ where
 
     /// Wrapper around [`Self::read`] that reads all pages of the result, handling pagination.
     ///
+    /// `tuple` may be:
+    ///
+    /// * `Some(filter)` — returns tuples matching the filter. The OpenFGA
+    ///   server requires `filter.object` to specify at least an object type,
+    ///   AND requires either a non-empty `filter.user` or a non-empty object
+    ///   id; a bare `"type:"` prefix on its own is rejected.
+    /// * `None` — **enumerates every tuple in the store**, paginating to
+    ///   completion. This is the supported global-tuple-enumeration primitive
+    ///   and is what the OpenFGA CLI's `fga store export` uses internally.
+    ///
+    /// `page_size` is capped at 100 by the OpenFGA Read RPC (proto-level
+    /// validation, not configurable).
+    ///
     /// # Errors
     /// * [`Error::RequestFailed`] If a request to OpenFGA fails.
     /// * [`Error::TooManyPages`] If the number of pages read exceeds `max_pages`.
@@ -459,6 +472,59 @@ pub(crate) mod test {
                 .expect("Read can be done");
 
             assert!(tuples.is_empty());
+        }
+
+        /// Direct low-level verification that `read_all_pages` with no filter
+        /// (`tuple=None`) returns *every* tuple in the store, across multiple
+        /// pages. Mirrors the high-level test in
+        /// `model_client::tests::openfga::test_read_all_pages_empty_tuple` but
+        /// exercises the [`OpenFgaServiceClient::read_all_pages`] entry point
+        /// directly so it doesn't regress if the high-level wrapper changes.
+        #[tokio::test]
+        async fn test_read_all_pages_unfiltered() {
+            let (mut client, store) = new_store().await;
+            let auth_model = create_entitlements_model(&mut client, &store).await;
+
+            // 250 distinct (user, relation, object) tuples spread across multiple
+            // objects so no single-key filter could fetch them. With page_size=100,
+            // this forces 3 pages of pagination.
+            let total = 250;
+            for i in 0..total {
+                client
+                    .write(WriteRequest {
+                        authorization_model_id: auth_model.authorization_model_id.clone(),
+                        store_id: store.id.clone(),
+                        writes: Some(WriteRequestWrites {
+                            on_duplicate: String::new(),
+                            tuple_keys: vec![TupleKey {
+                                user: format!("user:u-{i}"),
+                                relation: "member".to_string(),
+                                object: format!("organization:org-{}", i % 5),
+                                condition: None,
+                            }],
+                        }),
+                        deletes: None,
+                    })
+                    .await
+                    .expect("write can be done");
+            }
+
+            let tuples = client
+                .read_all_pages(
+                    &store.id,
+                    None::<ReadRequestTupleKey>,
+                    ConsistencyPreference::HigherConsistency,
+                    100,
+                    10,
+                )
+                .await
+                .expect("unfiltered read_all_pages must succeed");
+
+            assert_eq!(
+                tuples.len(),
+                total,
+                "unfiltered read_all_pages must return every tuple in the store"
+            );
         }
     }
 }

--- a/src/client_ext.rs
+++ b/src/client_ext.rs
@@ -228,13 +228,13 @@ where
                 .into_inner();
             tuples.extend(response.tuples);
             continuation_token.clone_from(&response.continuation_token);
-            if continuation_token.is_empty() || count > max_pages {
-                if count > max_pages {
-                    return Err(Error::TooManyPages { max_pages, tuple });
-                }
+            count += 1;
+            if count > max_pages {
+                return Err(Error::TooManyPages { max_pages, tuple });
+            }
+            if continuation_token.is_empty() {
                 break;
             }
-            count += 1;
         }
 
         Ok(tuples)
@@ -525,6 +525,65 @@ pub(crate) mod test {
                 total,
                 "unfiltered read_all_pages must return every tuple in the store"
             );
+        }
+
+        /// Regression test for the off-by-two pagination cap.
+        ///
+        /// `max_pages = N` is contractually documented as "the read errors if
+        /// the response would require more than N pages". The pre-fix logic
+        /// allowed up to `N + 2` pages of data to come back successfully (the
+        /// counter was checked before being incremented, so `count > max_pages`
+        /// only fired two iterations after the limit was reached).
+        ///
+        /// We write enough data to require 3 pages and ask for `max_pages = 1`
+        /// — the call must error with [`Error::TooManyPages`], not return
+        /// silently.
+        #[tokio::test]
+        async fn test_read_all_pages_max_pages_enforced() {
+            let (mut client, store) = new_store().await;
+            let auth_model = create_entitlements_model(&mut client, &store).await;
+
+            // 3 pages worth at page_size=100 → 250 tuples.
+            for i in 0..250 {
+                client
+                    .write(WriteRequest {
+                        authorization_model_id: auth_model.authorization_model_id.clone(),
+                        store_id: store.id.clone(),
+                        writes: Some(WriteRequestWrites {
+                            on_duplicate: String::new(),
+                            tuple_keys: vec![TupleKey {
+                                user: format!("user:u-{i}"),
+                                relation: "member".to_string(),
+                                object: "organization:org-1".to_string(),
+                                condition: None,
+                            }],
+                        }),
+                        deletes: None,
+                    })
+                    .await
+                    .expect("write can be done");
+            }
+
+            let result = client
+                .read_all_pages(
+                    &store.id,
+                    None::<ReadRequestTupleKey>,
+                    ConsistencyPreference::HigherConsistency,
+                    100,
+                    1, // strictly fewer than the 3 pages of data
+                )
+                .await;
+
+            match result {
+                Err(Error::TooManyPages { max_pages, .. }) => {
+                    assert_eq!(max_pages, 1);
+                }
+                Err(other) => panic!("expected TooManyPages, got {other:?}"),
+                Ok(tuples) => panic!(
+                    "expected TooManyPages error, got Ok with {} tuples",
+                    tuples.len()
+                ),
+            }
         }
     }
 }

--- a/src/model_client.rs
+++ b/src/model_client.rs
@@ -338,25 +338,67 @@ where
             .map(|_| ())
     }
 
-    /// Read tuples from OpenFGA.
+    /// Read tuples from OpenFGA, single page.
+    ///
+    /// `tuple_key` may be:
+    ///
+    /// * A specific [`ReadRequestTupleKey`] — returns tuples matching that
+    ///   filter. The OpenFGA server requires the filter to specify either a
+    ///   non-empty `user` or a non-empty object id (a bare `"type:"` prefix is
+    ///   *not* enough on its own).
+    /// * `None` — returns **every tuple in the store**, no filter applied.
+    ///   This is the same primitive used by the OpenFGA CLI's
+    ///   `fga store export` and is the only way to enumerate tuples without
+    ///   already knowing every user/object id.
+    ///
+    /// Note that OpenFGA's `Read` RPC caps `page_size` at 100 (proto-level
+    /// validation, not configurable). Larger requested values are rejected.
+    ///
     /// This is a wrapper around [`OpenFgaServiceClient::read`] that:
     ///
     /// * Traces any errors that occur
     /// * Enriches the error with the `read_request` that caused the error
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use openfga_client::client::{OpenFgaClient, OpenFgaServiceClient, ReadRequestTupleKey};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let service_client = OpenFgaServiceClient::connect("http://localhost:8080").await?;
+    /// let client = OpenFgaClient::new(service_client, "store_id", "model_id");
+    ///
+    /// // Filtered read — bare ReadRequestTupleKey is auto-wrapped via Into<Option<_>>.
+    /// let _filtered = client
+    ///     .read(
+    ///         100,
+    ///         ReadRequestTupleKey {
+    ///             user: "user:alice".to_string(),
+    ///             relation: "member".to_string(),
+    ///             object: "team:".to_string(),
+    ///         },
+    ///         None::<String>,
+    ///     )
+    ///     .await?;
+    ///
+    /// // Unfiltered — pass `None` to enumerate everything in the store.
+    /// let _all = client.read(100, None, None::<String>).await?;
+    /// # Ok(()) }
+    /// ```
     ///
     /// # Errors
     /// * [`Error::RequestFailed`] if the read request fails
     pub async fn read(
         &self,
         page_size: i32,
-        tuple_key: impl Into<ReadRequestTupleKey>,
+        tuple_key: impl Into<Option<ReadRequestTupleKey>>,
         continuation_token: impl Into<Option<String>>,
     ) -> Result<tonic::Response<ReadResponse>> {
         let read_request = ReadRequest {
             store_id: self.store_id().to_string(),
             page_size: Some(page_size),
             continuation_token: continuation_token.into().unwrap_or_default(),
-            tuple_key: Some(tuple_key.into()),
+            tuple_key: tuple_key.into(),
             consistency: self.consistency().into(),
         };
         self.client
@@ -373,7 +415,17 @@ where
     }
 
     /// Read all tuples, with pagination.
-    /// For details on the parameters, see [`OpenFgaServiceClient::read_all_pages`].
+    ///
+    /// `tuple` may be:
+    ///
+    /// * `Some(filter)` — returns tuples matching the filter (paginated). Same
+    ///   server-side filter requirements as [`Self::read`].
+    /// * `None` — **enumerates every tuple in the store**, paginating to
+    ///   completion. This is the supported way to back up or audit a store and
+    ///   is what the OpenFGA CLI's `fga store export` uses internally.
+    ///
+    /// For details on the other parameters, see
+    /// [`OpenFgaServiceClient::read_all_pages`].
     ///
     /// # Errors
     /// * [`Error::RequestFailed`] If a request to OpenFGA fails.
@@ -721,6 +773,114 @@ mod tests {
             OpenFgaClient::new(service_client, &store.id, auth_model_id.as_str())
         }
 
+        /// Verifies that the single-page [`OpenFgaClient::read`] honours
+        /// `tuple_key=None` as "no filter" and returns store-wide tuples,
+        /// providing a continuation token when more pages are available.
+        #[tokio::test]
+        #[traced_test]
+        async fn test_read_single_page_unfiltered() {
+            let client = get_client_with_custom_roles_model().await;
+
+            // Write 75 tuples — small enough to fit in one page of 100 but
+            // larger than a page of 50 so we also exercise the continuation token.
+            let total = 75;
+            for i in 0..total {
+                client
+                    .write(
+                        vec![TupleKey {
+                            user: format!("user:user{i}"),
+                            relation: "member".to_string(),
+                            object: "team:team1".to_string(),
+                            condition: None,
+                        }],
+                        None,
+                    )
+                    .await
+                    .unwrap();
+            }
+
+            // page_size=100: one page, no continuation, all 75 returned.
+            let resp = client
+                .read(100, None, None::<String>)
+                .await
+                .expect("read with None tuple_key must succeed");
+            let inner = resp.into_inner();
+            assert_eq!(inner.tuples.len(), total);
+            assert!(
+                inner.continuation_token.is_empty(),
+                "continuation token must be empty when all results fit in one page"
+            );
+
+            // page_size=50: first page returns 50, with a non-empty continuation.
+            let resp = client
+                .read(50, None, None::<String>)
+                .await
+                .expect("read with None tuple_key must succeed");
+            let inner = resp.into_inner();
+            assert_eq!(inner.tuples.len(), 50);
+            assert!(
+                !inner.continuation_token.is_empty(),
+                "continuation token must be set when more pages are available"
+            );
+
+            // Follow the continuation; remaining 25 tuples come back, no further pages.
+            let resp = client
+                .read(50, None, Some(inner.continuation_token))
+                .await
+                .expect("read with continuation token must succeed");
+            let inner = resp.into_inner();
+            assert_eq!(inner.tuples.len(), total - 50);
+            assert!(inner.continuation_token.is_empty());
+        }
+
+        /// Verifies that the bare-`ReadRequestTupleKey` call pattern (used
+        /// throughout this codebase before the signature was widened to accept
+        /// `Option<...>`) still compiles and works. Relies on the
+        /// `T: Into<Option<T>>` blanket impl.
+        #[tokio::test]
+        #[traced_test]
+        async fn test_read_single_page_filtered_backward_compat() {
+            let client = get_client_with_custom_roles_model().await;
+
+            client
+                .write(
+                    vec![
+                        TupleKey {
+                            user: "user:alice".to_string(),
+                            relation: "member".to_string(),
+                            object: "team:team1".to_string(),
+                            condition: None,
+                        },
+                        TupleKey {
+                            user: "user:bob".to_string(),
+                            relation: "member".to_string(),
+                            object: "team:team2".to_string(),
+                            condition: None,
+                        },
+                    ],
+                    None,
+                )
+                .await
+                .unwrap();
+
+            // Pass `ReadRequestTupleKey` directly — no `Some(...)` wrap.
+            let resp = client
+                .read(
+                    100,
+                    ReadRequestTupleKey {
+                        user: String::new(),
+                        relation: "member".to_string(),
+                        object: "team:team1".to_string(),
+                    },
+                    None::<String>,
+                )
+                .await
+                .unwrap();
+            let inner = resp.into_inner();
+            assert_eq!(inner.tuples.len(), 1);
+            assert_eq!(inner.tuples[0].key.as_ref().unwrap().user, "user:alice");
+        }
+
         /// Verifies that all pages are read when *not* passing a `ReadRequestTupleKey`.
         #[tokio::test]
         #[traced_test]
@@ -991,6 +1151,7 @@ mod tests {
 
         #[tokio::test]
         #[traced_test]
+        #[allow(clippy::similar_names)]
         async fn test_write_with_options_mixed_operations() {
             let client = get_client_with_custom_roles_model().await;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `read` now accepts explicit None to request unfiltered, store-wide tuple enumeration with pagination.

* **Documentation**
  * Clarified tuple-filtering semantics and store-wide enumeration behavior.
  * Expanded pagination docs, including server page-size and continuation-token details.

* **Bug Fixes**
  * Enforced max-pages limit immediately to prevent off-by-one over-pagination.

* **Tests**
  * Added async tests for unfiltered multi-page enumeration and max-pages regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->