### PR TITLE
chore(deps): bump middle 0.4 -> 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-stream = "0.3"
 futures = "0.3"
 futures-timer = "3.0.3"
 http = "1"
-middle = { version = "0.4.0", optional = true, features = ["tonic"] }
+middle = { version = "0.5.0", optional = true, features = ["tonic"] }
 prost = { version = "0.14", features = ["std"] }
 prost-types = "0.14"
 prost-wkt = "0.7"


### PR DESCRIPTION
Pulls the client-credentials token-refresh reliability fixes (retain a valid token on refresh failure, reject expired tokens, tracing span fix) and the cached tonic MetadataValue into the auth-middle path. No code changes needed; middle::Error is only wrapped as a #[source].